### PR TITLE
justfile: Rework to support environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Only use `stone.yaml` path now please.
 stone.yml
+
+# Used by just for loading environment variables specific to local systems
+.env

--- a/README.md
+++ b/README.md
@@ -36,9 +36,25 @@ our local repository priority to take precedence.
 $ boulder profile add local-x86_64 --repo name=volatile,uri=https://dev.serpentos.com/volatile/x86_64/stone.index,priority=0 --repo name=local,uri=file:///$HOME/.local_repo/stone.index,priority=10
 ```
 
+**Create a `.env` file**
+
+If you are not building on Serpent OS using the os-supplied boulder package, or if you want to specify custom arguments to the boulder invocation when using the `just` targets,
+you might benefit from creating a `.env` file in the root of the `recipes/` directory, next to the supplied `justfile`.
+
+_Example `.env` file:_
+
+    BOULDER="${HOME}/.local/bin/boulder"
+    BOULDER_ARGS="--data-dir=${HOME}/.local/share/boulder --config-dir=${HOME}/.config/boulder --moss-root=${HOME}/.cache/boulder""
+
+The `justfile` is set up so you can also choose to specify either of the above environment variables on a command-line invocation of `just`:
+
+_Example:_
+
+    BOULDER_ARGS="--data-dir=${HOME}/.local/share/boulder" just build
+
 ### Go go go
 
-Well, actually Rust.. Anyway, quickly try to build `m/m4/stone.yaml` or `n/nano/stone.yaml` for a quick and easy confirmation that everything works OK.
+Well, actually Rust.. Anyway, quickly try to `pushd m/m4/ && just build` or `pushd n/nano && just build` for a quick and easy confirmation that everything works OK.
 
 ## Git summary requirements
 

--- a/justfile
+++ b/justfile
@@ -1,18 +1,24 @@
 default: (_build build_file)
 
+set dotenv-load
+# respect BOULDER=<...> and BOULDER_ARGS=<...> set in .env file next to the present justfile
+boulder := env_var_or_default('BOULDER', 'boulder')
+boulder_args := env_var_or_default('BOULDER_ARGS', '')
 boulder_profile := env_var_or_default('BOULDER_PROFILE', 'local-x86_64')
 build_file := join(invocation_directory(), "stone.yaml")
 
 # Build the stone.yaml recipe using boulder
 _build target:
-    cd {{ invocation_directory() }}; boulder build -u {{ if path_exists(target) == "true" { target } else { error("Missing stone.yaml file") } }} -p {{ boulder_profile }}
+    cd {{ invocation_directory() }}
+    {{boulder}} {{boulder_args}} build -u {{ if path_exists(target) == "true" { target } else { error("Missing stone.yaml file") } }} -p {{ boulder_profile }}
 
 # Build stone.yaml from the current directory
 build: (_build build_file)
 
 # Chroot into target from stone.yaml recipe with boulder
 _chroot target:
-    cd {{ invocation_directory() }}; boulder chroot {{ if path_exists(target) == "true" { target } else { error("Missing stone.yaml file") } }}
+    cd {{ invocation_directory() }}
+    {{boulder}} {{boulder_args}} chroot {{ if path_exists(target) == "true" { target } else { error("Missing stone.yaml file") } }}
 
 # Chroot into pkg from the current directory
 chroot: (_chroot build_file)


### PR DESCRIPTION
Adds support for setting `BOULDER` and `BOULDER_ARGS` env variables, both from the command-line, via shell exports and via a `.env` file next to the recipes/ `justfile`.

README.md has been updated to reflect the new capabilities.