### PR TITLE
Various useful recipes/ tree tweaks to git hooks and justfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We'll add the (unversioned) volatile repository¹ at the bottom layer, and eleva
 local repository priority to take precedence.
 
 ```bash
-$ boulder profile add local-x86_64 --repo name=volatile,uri=https://dev.serpentos.com/volatile/x86_64/stone.index,priority=0 --repo name=local,uri=file:///${HOME}/.local_repo/stone.index,priority=10
+$ boulder profile add local-x86_64 --repo name=volatile,uri=https://dev.serpentos.com/volatile/x86_64/stone.index,priority=0 --repo name=local,uri=file://${HOME}/.cache/local_repo/x86_64/stone.index,priority=10
 ```
 
 ¹ the current one and only official online repository that you usually get all your packages from

--- a/tools/prepare-commit-msg.py
+++ b/tools/prepare-commit-msg.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from typing import Any
 
-scope_help = "# Scope and title, eg: nano: Update to 1.2.3\n"
+scope_help = "# Scope and title, eg: nano: Update to v1.2.3\n"
 help_msg = """
 
 # Describe or link the changes here, for example:
@@ -53,8 +53,8 @@ def commit_scope(commit_dir: str) -> str:
                     data = json.load(manifest, cls=JSONWithCommentsDecoder)
                     version = data["source-version"]
                     if data["source-release"] == "1":
-                        return os.path.basename(commit_dir) + ': Add at ' + str(version)
-                    return os.path.basename(commit_dir) + ': Update to ' + str(version)
+                        return os.path.basename(commit_dir) + ': Add at v' + str(version)
+                    return os.path.basename(commit_dir) + ': Update to v' + str(version)
                 except json.JSONDecodeError as e:
                     print(e)
 


### PR DESCRIPTION
**Add {create,index,ls,mv}-local targets**

All targets use the LOCAL_REPO environment variable.

The default LOCAL_REPO location is set to:

    ${HOME}/.cache/local_repo/x86_64

for XDG compliance.

This can trivially be overridden in the `recipes/.env` file or via an
environment variable, which is expected to be useful for stack work.

If the LOCAL_REPO dir does not exist, it will be created first. This is
also intended to be useful for stack work.

Note that the options for the ls-local target file listing have been
carefully chosen so the list is sorted by file creation time, which is
useful for checking if things have been built in the correct order and
whether all files present have been indexed.

The README has been updated to reflect the defaults above.