### PR TITLE
tools: Add new function to bash helpers and new helpers for other shells 

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -73,6 +73,14 @@ function cpesearch() {
     fi
 }
 
+# Goes to the root directory of the serpent recipes
+# git repository from anywhere on the filesystem.
+# This function will only work if this script is sourced
+# by your bash shell.
+function gotoserpentrepo() {
+    cd "$(dirname "$(readlink "${BASH_SOURCE[0]}")")/../" || return 1
+}
+
 # Goes to the root directory of the git repository
 function goroot() {
     cd "$(git rev-parse --show-toplevel)" || return 1

--- a/tools/helpers.fish
+++ b/tools/helpers.fish
@@ -1,0 +1,37 @@
+#!/usr/bin/env fish
+function __serpent_repo_dir
+    realpath (dirname (readlink (status -f)))/../
+end
+
+function __serpent_toplevel
+    git rev-parse --show-toplevel
+end
+
+function cpesearch -d "Search for known CPE entries for a program or library"
+    if test "$argv[1]" = "--help"; or test "$argv[1]" = "-h"; or test (count $argv) -ne 1
+        echo "usage: cpesearch <package-name>"
+    else
+        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$argv[1]\"]}" | jq .
+        
+        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT"        
+    end
+end
+
+function gotoserpentrepo -d "Go to the root of the Serpent recipes repository"
+    cd (__serpent_repo_dir)
+end
+
+function goroot -d "Go to the root of the current Git repository"
+    cd (__serpent_toplevel)
+end
+
+function chpkg -a package -d "Go to a package directory"
+    cd (__serpent_toplevel)/*/$package
+end
+
+complete -c gotoserpentrepo -f
+complete -c goroot -f
+complete -c chpkg -f
+complete -c chpkg -a "(path basename (__serpent_toplevel)/*/*)"
+

--- a/tools/helpers.zsh
+++ b/tools/helpers.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+
+# Primitive CPE search tool
+function cpesearch() {
+    if [[ -z $1 || $1 == "--help" || $1 == "-h" ]]; then
+        echo "usage: cpesearch <package-name>"
+    else
+        curl -s -X POST https://cpe-guesser.cve-search.org/search -d "{\"query\": [\"$1\"]}" | jq .
+        
+        echo "Verify successful hits by visiting https://cve.circl.lu/search/\$VENDOR/\$PRODUCT"
+        echo "- CPE entries for software applications have the form 'cpe:2.3:a:\$VENDOR:\$PRODUCT'"
+    fi
+}
+
+
+# Goes to the root directory of the serpent recipes
+# git repository from anywhere on the filesystem.
+# This function will only work if this script is sourced
+# by your zsh shell.
+function gotoserpentrepo() {
+    SCRIPT_PATH=$functions_source[gotoserpentrepo]
+    cd $(dirname $(readlink "${SCRIPT_PATH}"))/../
+}
+
+# Goes to the root directory of the git repository
+function goroot() {
+    cd $(git rev-parse --show-toplevel)
+}
+
+# Change into a package directory
+function chpkg() {
+    cd $(git rev-parse --show-toplevel)/*/$1
+}
+
+
+# Package name completion
+_chpkg()
+{
+    _list=$(ls $(git rev-parse --show-toplevel)/*/)
+
+    local cur prev
+    COMPREPLY=()
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    if [[ $COMP_CWORD -eq 1 ]] ; then
+        COMPREPLY=( $(compgen -W "${_list}" -- ${cur}) )
+        return 0
+    fi
+}
+
+complete -F _chpkg chpkg


### PR DESCRIPTION
**Summary**

- Add `gotoserpentrepo` function to bash helper script
- Add basic script to navigate the monorepo in fish and zsh