### PR TITLE
Fix repology warning

### DIFF
--- a/a/asciinema/stone.yaml
+++ b/a/asciinema/stone.yaml
@@ -6,7 +6,7 @@
 name        : asciinema
 version     : "3.0.0-rc.3"
 release     : 1
-homepage    : https://asciinema.oasciinema/
+homepage    : https://asciinema.org/
 upstreams   :
     - https://github.com/asciinema/asciinema/archive/refs/tags/v3.0.0-rc.3.tar.gz : 3e7402589eac1a704951e3c48d769f5d007c52630f17ec895dfad6676e4ba6b9
 summary     : Terminal session recorder

--- a/l/libcap-ng/stone.yaml
+++ b/l/libcap-ng/stone.yaml
@@ -8,7 +8,7 @@ version     : 0.8.5
 release     : 4
 summary     : Libcap-ng is a library that makes using posix capabilities easier
 license     : LGPL-2.1-or-later
-homepage    : http://people.redhat.com/sgrubb/libcap-ng/
+homepage    : https://people.redhat.com/sgrubb/libcap-ng/
 description : |
     The libcap-ng library should make programming with posix capabilities easier. The library has some utilities to help you analyse a system for apps that may have too much privileges.
 upstreams   :

--- a/m/mpc/stone.yaml
+++ b/m/mpc/stone.yaml
@@ -9,7 +9,7 @@ release     : 1
 summary     : Library for arbitrary precision arithmetic
 license     :
     - LGPL-3.0-or-later
-homepage    : http://www.multiprecision.org/mpc/
+homepage    : https://www.multiprecision.org/mpc/
 description : |
     Library for arbitrary precision arithmetic.
 upstreams   :

--- a/p/pixman/stone.yaml
+++ b/p/pixman/stone.yaml
@@ -6,7 +6,7 @@
 name        : pixman
 version     : 0.44.2
 release     : 6
-homepage    : http://www.pixman.org
+homepage    : https://www.pixman.org
 upstreams   :
     - https://gitlab.freedesktop.org/pixman/pixman/-/archive/pixman-0.44.2/pixman-pixman-0.44.2.tar.gz : 1ac33e229549f6341a677d530d1944431139d222ecad1554818788ae9ef32f6f
 summary     : Low-level library for pixel manipulation

--- a/p/pop-os-launcher/stone.yaml
+++ b/p/pop-os-launcher/stone.yaml
@@ -8,7 +8,7 @@ version     : "1.2.4"
 release     : 5
 summary     : Pop!_OS Launcher
 license     : MPL-2.0
-homepage    : https://github.com/pop-os/pop-os-launcher
+homepage    : https://github.com/pop-os/launcher
 upstreams   :
     - git|https://github.com/pop-os/launcher.git : fca3b25552deca3bd64de8bfd1ebb38c45e4fb39
 description : |

--- a/p/python-tomli/stone.yaml
+++ b/p/python-tomli/stone.yaml
@@ -6,7 +6,7 @@
 name        : python-tomli
 version     : 2.0.1
 release     : 1
-homepage    : https://pypi.io/packages/source/t/tomli
+homepage    : https://pypi.org/project/tomli/
 upstreams   :
     - https://pypi.io/packages/source/t/tomli/tomli-2.0.1.tar.gz : de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f
 summary     : Lil' TOML parser

--- a/q/qemu/stone.yaml
+++ b/q/qemu/stone.yaml
@@ -6,7 +6,7 @@
 name        : qemu
 version     : 9.2.0
 release     : 11
-homepage    : http://www.qemu-project.org/
+homepage    : http://www.qemu.org/
 upstreams   :
     - https://download.qemu.org/qemu-9.2.0.tar.xz : f859f0bc65e1f533d040bbe8c92bcfecee5af2c921a6687c652fb44d089bd894
 summary     :  A generic and open source machine emulator and virtualizer

--- a/s/sdl2/stone.yaml
+++ b/s/sdl2/stone.yaml
@@ -6,7 +6,7 @@
 name        : sdl2
 version     : 2.30.10
 release     : 4
-homepage    : https://libsdl.prg
+homepage    : https://libsdl.org
 upstreams   :
     - https://github.com/libsdl-org/SDL/releases/download/release-2.30.10/SDL2-2.30.10.tar.gz : f59adf36a0fcf4c94198e7d3d776c1b3824211ab7aeebeb31fe19836661196aa
 summary     : Simple DirectMedia Library

--- a/s/sound-theme-freedesktop/stone.yaml
+++ b/s/sound-theme-freedesktop/stone.yaml
@@ -8,7 +8,7 @@ version     : 0.8
 release     : 1
 homepage    : https://www.freedesktop.org/wiki/Specifications/sound-theme-spec/
 upstreams   :
-    - http://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-0.8.tar.bz2 : cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14
+    - https://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-0.8.tar.bz2 : cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14
 summary     : Freedesktop Sound Theme
 description : |
     Freedesktop Sound Theme


### PR DESCRIPTION
**Summary**

Fix all Repology warning mentioned in this [page](https://github.com/malfisya/serpent-recipes/pull/new/stfu-repology). Except for `nano`, `gmp`, and `python-ply`, these are false positives. Repology also doesn't provide an up-to-date info on dead links, the last time they checked it was  3 months ago (lol).