### PR TITLE
bash: read bashrc from profile

### DIFF
--- a/b/bash/manifest.x86_64.jsonc
+++ b/b/bash/manifest.x86_64.jsonc
@@ -197,6 +197,6 @@
 		}
 	},
 	"source-name": "bash",
-	"source-release": "16",
+	"source-release": "17",
 	"source-version": "5.2.37"
 }

--- a/b/bash/pkg/bashrc
+++ b/b/bash/pkg/bashrc
@@ -2,10 +2,6 @@
 
 alias ls="ls --color=auto -F"
 
-if [ -e /usr/share/defaults/etc/profile ] ; then
-    source /usr/share/defaults/etc/profile
-fi
-
 if [ -e /etc/bashrc ] ; then
     source /etc/bashrc
 fi

--- a/b/bash/pkg/profile
+++ b/b/bash/pkg/profile
@@ -1,5 +1,10 @@
 # Begin /usr/share/defaults/etc/profile
 
+# check for bashrc and source it
+if [ -e /usr/share/defaults/etc/bashrc ] ; then
+    source /usr/share/defaults/etc/bashrc
+fi
+
 # files in the below dir MUST be in portable .sh format!
 if [ -d /usr/share/defaults/etc/profile.d ] ; then
     for script in /usr/share/defaults/etc/profile.d/*.sh

--- a/b/bash/stone.yaml
+++ b/b/bash/stone.yaml
@@ -5,7 +5,7 @@
 #
 name        : bash
 version     : 5.2.37
-release     : 16
+release     : 17
 homepage    : http://www.gnu.org/software/bash/bash.html
 upstreams   :
     - https://ftp.gnu.org/gnu/bash/bash-5.2.37.tar.gz : 9599b22ecd1d5787ad7d3b7bf0c59f312b3396d1e281175dd1f8a4014da621ff


### PR DESCRIPTION
It seems that `/usr/share/default/etc/bashrc` isn't being read due to the `stateless.patch` not working

This workaround loads `bashrc` from `profile` in order to get the environment right.

The true fix would be to see what's missing from `stateless.patch`.