### PR TITLE
justfile: Add `monitoring-status` target

### DIFF
--- a/justfile
+++ b/justfile
@@ -68,6 +68,10 @@ index-local: create-local
 ls-local: create-local
     cd {{ invocation_directory() }} && ls -AFcghlot {{local_repo}}
 
+# check the entire tree for packages missing monitoring.yaml files
+monitoring-status:
+    find . -mindepth 2 -maxdepth 2 -type d ! -exec test -e '{}/monitoring.yaml' \; -print |grep -vE '^\./\.git|^\./tools' |sort -n
+
 # move .stones to LOCAL_REPO (create if it doesn't exist) and reindex it
 mv-local: create-local
     cd {{ invocation_directory() }} && mv -v *.stone {{local_repo}}/ && moss index {{local_repo}}


### PR DESCRIPTION
This will list the recipe directories with a `stone.yaml` recipe file, which are missing a corresponding `monitoring.yaml` file.

This is pure brute-force `find` invocation with no allowlist.

Usage:

`just monitoring-status`

**Test Plan**

Invoke `just monitoring-status` and see that it prints a list of directories missing a monitoring.yaml file.