### PR TITLE
Updated pkg/sudoers file with default secure_path variable

### DIFF
--- a/s/sudo-rs/pkg/sudoers
+++ b/s/sudo-rs/pkg/sudoers
@@ -3,6 +3,9 @@
 ## Please only use `visudo` to make changes, via snippets in
 ## `/etc/sudoers.d/*`
 
+# Add the default secure path
+Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+
 root ALL=(ALL:ALL) ALL
 
 # Permit "wheel" group to run any command


### PR DESCRIPTION
# What is the change?
Added the line `Defaults secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"` to the /usr/share/defaults/sudo/sudoer file.

## Reason for Change
This fixes an issue where new installs sudo implementation does not recognize any commands.

For example, before the change the command `sudo moss` would give an error that moss doesn't exist, when you were able to run the command without sudo successfully.

## Testing Completed
I have created a new install within a Virtual Machine and on bare metal. The issue was present after booting into the new install. I updated the local repo with the change, indexed the local repo, and then ran `moss sync -u` with the local repo enabled. This installed the patched version of sudo-rs within this PR, and the issue was resolved.