### PR TITLE
Fix usage of old starship preset name

### DIFF
--- a/s/starship/pkg/50-starship.sh
+++ b/s/starship/pkg/50-starship.sh
@@ -11,7 +11,7 @@ case "$TERM" in
     "linux") return 0;;
 esac
 
-# Initialise starship prompt with serpent's default prompt
+# Initialise starship prompt with aeryn's default prompt
 [ ! -d ~/.config ] && mkdir ~/.config
 [ ! -e ~/.config/starship.toml ] && starship preset aeryn-os -o  ~/.config/starship.toml
 


### PR DESCRIPTION
'serpent-os' preset doesn't exist anymore, replaced with 'aeryn-os'

<img width="1260" height="188" alt="error: invalid value serpent-os for '[NAME]'. [possible values: aeryn-os, bracketed-segments, catppuccin-powerline, gruvbox-rainbow, jetpack, nerd-font-symbols, no-empty-icons, no-nerd-font, no-runtime-versions, pastel-powerline, plain-text-symbols, pure-preset, tokyo-night]. Tip: a similar value exists: aeryn-os" src="https://github.com/user-attachments/assets/d60b09f9-2d68-4f8b-a87f-601984e4fd73" />
