### PR TITLE
prismlauncher: fix rundeps

### DIFF
--- a/p/prism-launcher/stone.yaml
+++ b/p/prism-launcher/stone.yaml
@@ -20,16 +20,17 @@ builddeps   :
     - binary(java-17)
     - binary(scdoc)
     - cmake(ECM)
-    - cmake(cmark)
     - cmake(Qt6)
     - cmake(Qt6Core5Compat)
     - cmake(Qt6NetworkAuth)
+    - cmake(cmark)
     - cmake(tomlplusplus)
     - cmake(zlib)
     - pkgconfig(bzip2)
     - pkgconfig(gamemode)
 rundeps     :
     - binary(gamemoderun)
+    - binary(java-17)
     - binary(java-21)
     - qt6-wayland
 setup       : |


### PR DESCRIPTION
Java 17 isn't installed because it is not part of the rundeps as binary(name) isn't treated the same as pkgconfig(name) or cmake(name)

Force push was to fix builddeps order as I noticed that