### PR TITLE
[NFC] tools: Changes to bash helper

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -92,14 +92,14 @@ function goroot() {
 
 # Push into a package directory
 function chpkg() {
-    cd "$(git rev-parse --show-toplevel)"/*/"$1" || return 1
+    cd "$(git rev-parse --show-toplevel)"/${1:0:1}/"$1" || return 1
 }
 
 # Bash completions
 _chpkg()
 {
     # list of package directories we can go into
-    _list=$(ls "$(git rev-parse --show-toplevel)"/*/)
+    _list=$(basename -a "$(git rev-parse --show-toplevel)"/{a..z}/*)
 
     local cur
     COMPREPLY=()


### PR DESCRIPTION
I believe this would be less fragile (it completely ignores paths that aren't **_firstletter_**/**_packagename_**)

probably should update the other scripts to be similar if this behavior is prefered.
draft now because haven't tested with anything other than brush and also the above.