### PR TITLE
Update GnuPG version to 2.5.17 in stone.yaml

### DIFF
--- a/g/gnupg/stone.yaml
+++ b/g/gnupg/stone.yaml
@@ -8,7 +8,7 @@ version     : 2.5.16
 release     : 10
 homepage    : https://gnupg.org/software/index.html
 upstreams   :
-    - https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.16.tar.bz2 : 05144040fedb828ced2a6bafa2c4a0479ee4cceacf3b6d68ccc75b175ac13b7e
+    - https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.5.17.tar.bz2 : 2c1fbe20e2958fd8fb53cf37d7c38e84a900edc0d561a1c4af4bc3a10888685d
 summary     : Complete and free implementation of the OpenPGP standard to encrypt communications and files
 description : |
     %(name) is a complete and free implementation of the OpenPGP standard as defined by RFC4880, also known as PGP. GnuPG allows you to encrypt and sign your data and communications; it features a versatile key management system, along with access modules for all kinds of public key directories. GnuPG, also known as GPG, is a command line tool with features for easy integration with other applications. A wealth of frontend applications and libraries are available. GnuPG also provides support for S/MIME and SSH.


### PR DESCRIPTION
**Summary**

Just putting out, no merging yet. New version. Was not build and need to check deps, etc.

> GnuPG 2.5.17 and Gpg4win 5.0.1 have been released to fix a severe security bug in GnuPG versions 2.5.13 to 2.5.16. Please update as soon as possible. 

**Test Plan**

Not tested yet.

**Checklist**

- [ ] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged  <!-- Write an appropriate message in the Summary section and add the "topic: highlight" label -->
