### PR TITLE
tools: Add fixup-recipe-commit to bash+zsh helpers

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -103,6 +103,32 @@ function fix-version-strings () {
     {} +
 }
 
+# Quickly fixup a recipe commit for a source package
+function fixup-recipe-commit() {
+    if [[ ! -f "stone.yaml" ]]; then
+        echo "No stone.yaml found in current directory, aborting!"
+        return 1
+    fi
+
+    if ! git status --porcelain -- . | grep -q '^ M'; then
+        echo "No files in current directory are modified, aborting!"
+        return 1
+    fi
+
+    # Be explicit about adding files specific to packaging to avoid adding aliens
+    local paths=(stone.yaml manifest.x86_64.bin  manifest.x86_64.jsonc monitoring.yaml pkg/)
+    for path in "${paths[@]}"; do
+        [[ -e $path ]] && git add "$path"
+    done
+
+    # Fixup the last commit in the directory
+    git commit --fixup "$(git log -1 --format="%h" -- .)"
+    git rebase origin/HEAD --autosquash --autostash
+
+    # Print out the commit for the user
+    git log -1 -- .
+}
+
 # Bash completions
 _chpkg()
 {

--- a/tools/helpers.zsh
+++ b/tools/helpers.zsh
@@ -49,6 +49,32 @@ function fix-version-strings () {
     {} +
 }
 
+# Quickly fixup a recipe commit for a source package
+function fixup-recipe-commit() {
+    if [[ ! -f "stone.yaml" ]]; then
+        echo "No stone.yaml found in current directory, aborting!"
+        return 1
+    fi
+
+    if ! git status --porcelain -- . | grep -q '^ M'; then
+        echo "No files in current directory are modified, aborting!"
+        return 1
+    fi
+
+    # Be explicit about adding files specific to packaging to avoid adding aliens
+    local paths=(stone.yaml manifest.x86_64.bin  manifest.x86_64.jsonc monitoring.yaml pkg/)
+    for path in "${paths[@]}"; do
+        [[ -e $path ]] && git add "$path"
+    done
+
+    # Fixup the last commit in the directory
+    git commit --fixup "$(git log -1 --format="%h" -- .)"
+    git rebase origin/HEAD --autosquash --autostash
+
+    # Print out the commit for the user
+    git log -1 -- .
+}
+
 
 # Package name completion
 _chpkg()


### PR DESCRIPTION
**Summary**

quickly fixup a recipe commit

**Test Plan**

Fixup the commits in #1407

**Checklist**

- [] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged  <!-- Write an appropriate message in the Summary section and add the "topic: highlight" label -->
