### PR TITLE
qemu: Update qemu-guest-agent.service to remove WantedBy

### DIFF
--- a/q/qemu/pkg/qemu-guest-agent.service
+++ b/q/qemu/pkg/qemu-guest-agent.service
@@ -13,4 +13,4 @@ Restart=always
 RestartSec=0
 
 [Install]
-WantedBy=dev-virtio\x2dports-org.qemu.guest_agent.0.device
+WantedBy=


### PR DESCRIPTION
Remove specific WantedBy target from service file.

<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

`dev-virtio\x2dports-org.qemu.guest_agent.0.device` was removed from `WantedBy`

**Test Plan**

I ran `sudo systemctl preset-all`. I believe hotplug should still work because we have `ENV{SYSTEMD_WANTS}=` in `99-qemu-guest-agent.rules`, so this is redundant and also introducing a warning.

However, anyone using the feature to auto-start on hotplug can confirm.

**Checklist**

- [ ] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged