### PR TITLE
tools: Remove deprecated gotoserpentrepo command from tools helpers

### DIFF
--- a/tools/helpers.bash
+++ b/tools/helpers.bash
@@ -82,10 +82,6 @@ function cpesearch() {
 function gotoaosrepo() {
     cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
 }
-# deprecated - use gotoaerynosrepo
-function gotoserpentrepo() {
-    cd "$(dirname "$(readlink -m "${BASH_SOURCE[0]}")")/../" || return 1
-}
 
 # Goes to the root directory of the git repository
 function goroot() {

--- a/tools/helpers.fish
+++ b/tools/helpers.fish
@@ -25,11 +25,6 @@ function gotoaosrepo -d "Go to the root of the AerynOS recipes repository"
     cd (__aos_repo_dir)
 end
 
-# Deprecated, use gotoasorepo
-function gotoserpentrepo -d "Go to the root of the Serpent recipes repository"
-    cd (__aos_repo_dir)
-end
-
 function goroot -d "Go to the root of the current Git repository"
     cd (__aos_toplevel)
 end
@@ -46,8 +41,6 @@ function fix-version-strings -d "Quote unquoted version strings in recipes"
 end
 
 complete -c gotoaosrepo -f
-# Deprecated, remove later
-complete -c gotoserpentrepo -f
 complete -c goroot -f
 complete -c chpkg -f
 complete -c chpkg -a "(path basename (__aos_toplevel)/*/*)"

--- a/tools/helpers.zsh
+++ b/tools/helpers.zsh
@@ -27,12 +27,6 @@ function gotoaosrepo() {
     cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
 }
 
-# Deprecated, use gotoaosrepo
-function gotoserpentrepo() {
-    SCRIPT_PATH=$functions_source[gotoserpentrepo]
-    cd $(dirname $(readlink -m "${SCRIPT_PATH}"))/../
-}
-
 # Goes to the root directory of the git repository
 function goroot() {
     cd $(git rev-parse --show-toplevel)


### PR DESCRIPTION
**Summary**
- Remove deprecated gotoserpentrepo command from helpers.bash, helpers.fish, helpers.zsh files.

**Test Plan**:

- open a new terminal
- Confirm that gotoserpentrepo command has being removed

<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

<!-- Info on what this pull request updates/changes/etc -->

**Test Plan**

<!-- Short description of how the package was tested -->

**Checklist**

- [x] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
