### PR TITLE
[NFC] suitesparse: remove build failure workaround

### DIFF
--- a/s/suitesparse/stone.yaml
+++ b/s/suitesparse/stone.yaml
@@ -21,9 +21,6 @@ builddeps   :
     - pkgconfig(tbb)
     # - cuda
 setup       : |
-    # glibc 2.43 build failure, remove in future version
-    export CFLAGS+=" -Wno-error=incompatible-pointer-types"
-
     # 2026-04-27: Added cholmod, klu, and umfpack for eigen
     _projects="cholmod;klu;umfpack"
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 AerynOS Developers
SPDX-License-Identifier: MPL-2.0
-->

**Summary**

Since glibc got updated, the workaround is not needed anymore for a build.

**Test Plan**

Removed patch and checked if it build. Manifest stayed the same (as it should be).

**Checklist**

- [x] Recipe was built and tested against the volatile stream
- [ ] This change could gainfully be highlighted in the Stream Update notes once merged
  <!-- Write an appropriate message in the Summary section -->
